### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.stalker/addon.xml
+++ b/pvr.stalker/addon.xml
@@ -6,7 +6,7 @@
   provider-name="dvbken">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.stalker/addon.xml
+++ b/pvr.stalker/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="0.8.1"
+  version="0.9.0"
   name="Stalker Client"
   provider-name="dvbken">
   <requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,5 +1,9 @@
+0.9.0 (07-03-2015)
+- updated to PVR API version 1.9.7
+
 0.8.1 (28-06-2015)
 - updated language files from Transifex
+
 0.8.0 (05-24-2015)
 - added XMLTV support
 - added multi-portal support

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -362,8 +362,9 @@ int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; 
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY edl[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool OpenLiveStream(const PVR_CHANNEL &channel) { return false; }
 void CloseLiveStream(void) {}


### PR DESCRIPTION
For, J**** PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J**** and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.