### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="0.9.6"
+  version="0.9.7"
   name="Stalker Client"
   provider-name="kenji123">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,6 @@
+0.9.7 (19-09-2015)
+- Updated to PVR API v4.1.0
+
 0.9.6 (09-09-2015)
 - Updated to PVR API v4.0.0
 

--- a/src/SData.cpp
+++ b/src/SData.cpp
@@ -411,6 +411,7 @@ int SData::ParseEPG(Json::Value &parsed, time_t iStart, time_t iEnd, int iChanne
     tag.startTime = iStartTimestamp;
     tag.endTime = iStopTimestamp;
     tag.strPlot = (*it)["descr"].asCString();
+    tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
 
     PVR->TransferEpgEntry(handle, &tag);
     iEntriesTransfered++;
@@ -469,6 +470,7 @@ int SData::ParseEPGXMLTV(int iChannelNumber, std::string &strChannelName, time_t
     tag.iStarRating = Utils::StringToInt(it->strStarRating.substr(0, 1)); // numerator only
     tag.iEpisodeNumber = it->iEpisodeNumber;
     tag.strEpisodeName = it->strSubTitle.c_str();
+    tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
     
     PVR->TransferEpgEntry(handle, &tag);
     iEntriesTransfered++;


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075