### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)

--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="2.3.2"
+  version="2.4.0"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,6 @@
+2.4.0 (18-05-2016)
+- Cmake: rename find_package kodi to Kodi
+
 2.3.2 (13-05-2016)
 - Fix includes
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in