### PR TITLE
vs2015 fixes

### DIFF
--- a/depends/common/libxml2/libxml2.txt
+++ b/depends/common/libxml2/libxml2.txt
@@ -1,1 +1,1 @@
-libxml2 http://xmlsoft.org/sources/libxml2-2.9.3.tar.gz
+libxml2 http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz

--- a/src/XMLTV.cpp
+++ b/src/XMLTV.cpp
@@ -23,6 +23,7 @@
 #include "XMLTV.h"
 
 #include <algorithm>
+#include <iterator>
 
 #include "p8-platform/util/StringUtils.h"
 


### PR DESCRIPTION
Most recent libxml2 version has vs2015 compiler check (a probably others) that fixes #62.