### PR TITLE
[debian] disable LTO

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1
 
 override_dh_strip:
 	dh_strip -pkodi-pvr-stalker --dbg-package=kodi-pvr-stalker-dbg


### PR DESCRIPTION
Ubuntu builds are currently unusable. I think this is what's causing it.

Would it be of any use to make this change to the Jarvis branch as well?
