### PR TITLE
Krypton: src/CWatchdog.h: Fix gcc7 build

### DIFF
--- a/src/CWatchdog.h
+++ b/src/CWatchdog.h
@@ -22,6 +22,7 @@
  */
 
 #include <thread>
+#include <functional>
 
 #include "SAPI.h"
 


### PR DESCRIPTION
Building with gcc7 is broken:

src/CWatchdog.h:31:58: error: 'std::function' has not been declared
    CWatchdog(unsigned int interval, SAPI *api, std::function<void(SError)> errorCallback);
                                                     ^~~~~~~~

Backport of https://github.com/kodi-pvr/pvr.stalker/pull/92