### PR TITLE
[Testing Required] update to PVR addon API 5.7.0

### DIFF
--- a/depends/common/jsoncpp/jsoncpp.txt
+++ b/depends/common/jsoncpp/jsoncpp.txt
@@ -1,1 +1,1 @@
-jsoncpp http://mirrors.kodi.tv/build-deps/sources/jsoncpp-src-0.5.0.tar.gz
+jsoncpp https://github.com/open-source-parsers/jsoncpp/archive/0.10.6.tar.gz

--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="3.1.1"
+  version="3.2.0"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,4 +1,8 @@
 3.1.0
+- Updated to PVR addon API v5.7.0
+- Bump jsoncpp to 0.10.6
+
+3.1.0
 - Updated to PVR addon API v5.3.0
 
 3.0.4

--- a/src/SData.cpp
+++ b/src/SData.cpp
@@ -341,7 +341,7 @@ PVR_ERROR SData::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channe
 
         tag.iUniqueBroadcastId = event->uniqueBroadcastId;
         tag.strTitle = event->title.c_str();
-        tag.iChannelNumber = event->channelNumber;
+        tag.iUniqueChannelId = chan->uniqueId;
         tag.startTime = event->startTime;
         tag.endTime = event->endTime;
         tag.strPlot = event->plot.c_str();
@@ -501,7 +501,6 @@ PVR_ERROR SData::GetChannels(ADDON_HANDLE handle, bool radio) {
         tag.bIsRadio = false;
         tag.iChannelNumber = channel->number;
         strncpy(tag.strChannelName, channel->name.c_str(), sizeof(tag.strChannelName) - 1);
-        strncpy(tag.strStreamURL, channel->streamUrl.c_str(), sizeof(tag.strStreamURL) - 1);
         strncpy(tag.strIconPath, channel->iconPath.c_str(), sizeof(tag.strIconPath) - 1);
         tag.bIsHidden = false;
 
@@ -509,6 +508,29 @@ PVR_ERROR SData::GetChannels(ADDON_HANDLE handle, bool radio) {
     }
 
     return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR SData::GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount)
+{
+  std::string strUrl;
+  std::vector<SC::Channel> channels;
+  channels = m_channelManager->GetChannels();
+  for (const auto& stalkerChannel : channels)
+  {
+    if (stalkerChannel.uniqueId == channel->iUniqueId)
+    {
+      strUrl = stalkerChannel.streamUrl;
+    }
+  }
+  if (strUrl.empty()) {
+    return PVR_ERROR_FAILED;
+  }
+  strncpy(properties[0].strName, PVR_STREAM_PROPERTY_STREAMURL, sizeof(properties[0].strName));
+  strncpy(properties[0].strValue, strUrl.c_str(), sizeof(properties[0].strValue));
+
+  *iPropertiesCount = 1;
+
+  return PVR_ERROR_NO_ERROR;
 }
 
 const char *SData::GetChannelStreamURL(const PVR_CHANNEL &channel) {

--- a/src/SData.h
+++ b/src/SData.h
@@ -62,6 +62,8 @@ public:
 
     virtual const char *GetChannelStreamURL(const PVR_CHANNEL &channel);
 
+    virtual PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount);
+
     SC::Settings settings;
 protected:
     virtual bool LoadCache();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -274,8 +274,11 @@ const char *GetLiveStreamURL(const PVR_CHANNEL &channel) {
     return url;
 }
 
-unsigned int GetChannelSwitchDelay(void) {
-    return 0;
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL* channel, PVR_NAMED_VALUE* properties, unsigned int* iPropertiesCount) {
+  if (!m_data)
+    return PVR_ERROR_SERVER_ERROR;
+
+  return m_data->GetChannelStreamProperties(channel, properties, iPropertiesCount);
 }
 
 /** UNUSED API FUNCTIONS */
@@ -311,12 +314,12 @@ int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize) { return -1
 long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */) { return -1; }
 long long PositionLiveStream(void) { return -1; }
 long long LengthLiveStream(void) { return -1; }
-bool SwitchChannel(const PVR_CHANNEL &channel) { return false; }
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES *pProperties) { return PVR_ERROR_NOT_IMPLEMENTED; }
 bool OpenRecordedStream(const PVR_RECORDING &recording) { return false; }
 void CloseRecordedStream(void) { }
 int ReadRecordedStream(unsigned char *pBuffer, unsigned int iBufferSize) { return -1; }
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 long long SeekRecordedStream(long long iPosition, int iWhence /* = SEEK_SET */) { return -1; }
 long long PositionRecordedStream(void) { return -1; }
 long long LengthRecordedStream(void) { return -1; }
@@ -337,5 +340,8 @@ time_t GetBufferTimeEnd() { return 0; }
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 }


### PR DESCRIPTION
This brings the addon upto API 5.7.0 compatibility
Removed deprecated methods and stubbed out new ones. Implemented GetChannelStreamProperties() which should work, but requires verification.
Bumped jsoncpp to 0.10.6

Please note, ive not been able to test functionality at all. If anyone can let me know if the changes work, or need further tweaking. This was a quick attempt to get up and running, so feedback is very appreciated.