### PR TITLE
jsoncpp deprecated function change

### DIFF
--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="3.3.0"
+  version="3.3.1"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,6 @@
+3.3.1
+- Replace deprecated jsoncpp function
+
 3.3.0
 - Updated to PVR addon API v5.8.0
 


### PR DESCRIPTION
Same deal as the others. Changes deprecated function to charreader

Not runtime tested, but based on pvr.hdhomerun changes that have been.