### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,11 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(JsonCpp REQUIRED)
 
 include_directories(
-        ${kodiplatform_INCLUDE_DIRS}
         ${p8-platform_INCLUDE_DIRS}
         ${KODI_INCLUDE_DIR}
         ${PROJECT_SOURCE_DIR}/lib

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-stalker
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               libkodiplatform-dev (>= 16.0.0), kodi-addon-dev,
+               libp8-platform-dev, kodi-addon-dev,
                zlib1g-dev, libxml2-dev, libjsoncpp-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
The pvr.stalker binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.