### PR TITLE
Release build fix for Windows/UWP/Xbox

### DIFF
--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="20.2.1"
+  version="20.2.2"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,6 @@
+v20.2.2
+- Fix libxml2 dependency for Windows/UWP/Xbox
+
 v20.2.1
 - Updated depends libxml2 to version 2.9.10
   - To fix some Windows UWP builds


### PR DESCRIPTION
v20.2.2
- Fix libxml2 dependency for Windows/UWP/Xbox

