### PR TITLE
Release build fix for Windows/UWP/Xbox - Matrix

### DIFF
--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="19.0.2"
+  version="19.0.3"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,6 @@
+v19.0.3
+- Fix libxml2 dependency for Windows/UWP/Xbox
+
 v19.0.2
 - Updated depends libxml2 to version 2.9.10
   - To fix some Windows UWP builds


### PR DESCRIPTION
v19.0.3
- Fix libxml2 dependency for Windows/UWP/Xbox