### PR TITLE
(Matrix) Fix issue #189 : "year" and "starRating" are optional in xmltv contract

### DIFF
--- a/lib/libstalkerclient/xmltv.c
+++ b/lib/libstalkerclient/xmltv.c
@@ -27,6 +27,8 @@
 
 #include "util.h"
 
+#include <kodi/addon-instance/pvr/EPG.h>
+
 void *sc_xmltv_create(enum sc_xmltv_strct type) {
     size_t size = 0;
     void *strct = NULL;
@@ -60,6 +62,7 @@ void *sc_xmltv_create(enum sc_xmltv_strct type) {
             sc_xmltv_programme_t *p = (sc_xmltv_programme_t *) strct;
             p->credits = sc_list_create();
             p->categories = sc_list_create();
+            p->episode_num = EPG_TAG_INVALID_SERIES_EPISODE;
             break;
         }
         default:

--- a/pvr.stalker/addon.xml.in
+++ b/pvr.stalker/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.stalker"
-  version="19.0.3"
+  version="19.0.4"
   name="Stalker Client"
   provider-name="Jamal Edey">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.stalker/changelog.txt
+++ b/pvr.stalker/changelog.txt
@@ -1,3 +1,7 @@
+v19.0.4
+- Fix issue #189 : "year" and "starRating" are optional in xmltv contract
+- Fix issue : init episodeNumber to undefined instead of "0"
+
 v19.0.3
 - Fix libxml2 dependency for Windows/UWP/Xbox
 

--- a/src/GuideManager.cpp
+++ b/src/GuideManager.cpp
@@ -183,12 +183,14 @@ int GuideManager::AddEvents(
         e.cast = p->extra.cast;
         e.directors = p->extra.directors;
         e.writers = p->extra.writers;
-        e.year = std::stoi(p->date.substr(0, 4));
+        if (!p->date.empty())
+          e.year = std::stoi(p->date.substr(0, 4));
         e.iconPath = p->icon;
         e.genreType = p->extra.genreType;
         e.genreDescription = p->extra.genreDescription;
         e.firstAired = p->previouslyShown;
-        e.starRating = std::stoi(p->starRating.substr(0, 1));
+        if (!p->starRating.empty())
+          e.starRating = std::stoi(p->starRating.substr(0, 1));
         e.episodeNumber = p->episodeNumber;
         e.episodeName = p->subTitle;
 


### PR DESCRIPTION
Didn't try it though. It's my very first project with Kofi development.
(I followed cmake instructions to compile but I didn't make it to built a dylib release to test irl)