### PR TITLE
Fix missing stdlib.h header

### DIFF
--- a/lib/libstalkerclient/xmltv.c
+++ b/lib/libstalkerclient/xmltv.c
@@ -23,6 +23,7 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "util.h"


### PR DESCRIPTION
Required for compiling with gcc-14

fixes:
```
../lib/libstalkerclient/xmltv.c: In function 'sc_xmltv_create':
../lib/libstalkerclient/xmltv.c:51:13: error: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
   51 |     strct = malloc(size);
      |             ^~~~~~
../lib/libstalkerclient/xmltv.c:31:1: note: include '<stdlib.h>' or provide a declaration of 'malloc'
   30 | #include <kodi/c-api/addon-instance/pvr/pvr_epg.h>
  +++ |+#include <stdlib.h>
   31 | 
../lib/libstalkerclient/xmltv.c:51:13: warning: incompatible implicit declaration of built-in function 'malloc' [-Wbuiltin-declaration-mismatch]
   51 |     strct = malloc(size);
      |             ^~~~~~
../lib/libstalkerclient/xmltv.c:51:13: note: include '<stdlib.h>' or provide a declaration of 'malloc'
../lib/libstalkerclient/xmltv.c: In function 'sc_xmltv_list_free':
../lib/libstalkerclient/xmltv.c:90:5: error: implicit declaration of function 'free' [-Wimplicit-function-declaration]
   90 |     free(*list);
      |     ^~~~
../lib/libstalkerclient/xmltv.c:90:5: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:90:5: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
../lib/libstalkerclient/xmltv.c:90:5: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c: In function 'sc_xmltv_free':
../lib/libstalkerclient/xmltv.c:101:25: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  101 |             if (c->id_) free(c->id_);
      |                         ^~~~
../lib/libstalkerclient/xmltv.c:101:25: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:114:29: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  114 |             if (p->channel) free(p->channel);
      |                             ^~~~
../lib/libstalkerclient/xmltv.c:114:29: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:116:27: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  116 |             if (p->title) free(p->title);
      |                           ^~~~
../lib/libstalkerclient/xmltv.c:116:27: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:118:31: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  118 |             if (p->sub_title) free(p->sub_title);
      |                               ^~~~
../lib/libstalkerclient/xmltv.c:118:31: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:120:26: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  120 |             if (p->desc) free(p->desc);
      |                          ^~~~
../lib/libstalkerclient/xmltv.c:120:26: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:125:26: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  125 |             if (p->date) free(p->date);
      |                          ^~~~
../lib/libstalkerclient/xmltv.c:125:26: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:132:33: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  132 |             if (p->star_rating) free(p->star_rating);
      |                                 ^~~~
../lib/libstalkerclient/xmltv.c:132:33: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:134:26: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  134 |             if (p->icon) free(p->icon);
      |                          ^~~~
../lib/libstalkerclient/xmltv.c:134:26: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:143:26: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  143 |             if (c->name) free(c->name);
      |                          ^~~~
../lib/libstalkerclient/xmltv.c:143:26: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c:150:5: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  150 |     free(strct);
      |     ^~~~
../lib/libstalkerclient/xmltv.c:150:5: note: include '<stdlib.h>' or provide a declaration of 'free'
../lib/libstalkerclient/xmltv.c: In function 'sc_xmltv_parse_programme':
../lib/libstalkerclient/xmltv.c:278:5: warning: incompatible implicit declaration of built-in function 'free' [-Wbuiltin-declaration-mismatch]
  278 |     free(val);
      |     ^~~~
../lib/libstalkerclient/xmltv.c:278:5: note: include '<stdlib.h>' or provide a declaration of 'free'
```